### PR TITLE
Fix to missing spaces between template fields (issue #133)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -252,7 +252,20 @@ var builder = {
       // include "after" XML string and the value to inject (_part.str) all the time, except at the beginning of if block
       if (!(_hideBlock > 0 && _prevHideBlock === 0)) {
         _str += _part.str;
-        _str += _part.aft !== undefined ? builderDictionary[_part.aft] : '';
+        let aftContent = _part.aft !== undefined ? builderDictionary[_part.aft] : '';
+
+        // replace leading and trailing spaces with non breaking spaces when inside <w:t>
+        const leadingSpacesRegex = /^([ ]+)<\/w:t>/;
+        const trailingSpacesRegex = /<w:t>([ ]+)$/;
+        const leadingMatch = aftContent.match(leadingSpacesRegex);
+        if (leadingMatch) {
+          aftContent = '\u00A0'.repeat(leadingMatch[1].length) + '</w:t>' + aftContent.substring(leadingMatch.index + leadingMatch[0].length);
+        }
+        const trailingMatch = aftContent.match(trailingSpacesRegex);
+        if (trailingMatch) {
+          aftContent = aftContent.substring(0, trailingMatch.index) + '<w:t>' + '\u00A0'.repeat(trailingMatch[1].length);
+        }
+        _str += aftContent;
       }
       _res += _str;
 


### PR DESCRIPTION
When template contains two fields on the same line separated by a space character sometimes Word (tested with v16.60 on Mac) saves the xml structure in such a way that the space doesn't appear in the resulting document.

#133 

<img width="472" alt="Screenshot 2022-04-25 at 16 41 59" src="https://user-images.githubusercontent.com/12734495/165113810-d1ac3353-e769-4f56-aee1-784b1ac275ab.png">

```
<w:p w14:paraId="4EA390C4" w14:textId="5D90251E" w:rsidR="00AD46B6" w:rsidRPr="00800E3B" w:rsidRDefault="00800E3B">
  <w:pPr>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
  </w:pPr>
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>Hello {</w:t>
  </w:r>
  <w:proofErr w:type="spellStart" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>d.firstname</w:t>
  </w:r>
  <w:proofErr w:type="spellEnd" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>} {</w:t>
  </w:r>
  <w:proofErr w:type="spellStart" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>d.lastname</w:t>
  </w:r>
  <w:proofErr w:type="spellEnd" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>}!</w:t>
  </w:r>
</w:p>
```

Document generated with values { firstname: "Firstname", lastname: "Lastname } then looks like this

![Screenshot 2022-04-25 at 16 44 13](https://user-images.githubusercontent.com/12734495/165115593-c491ec47-ee32-4494-8afb-9d33d6c3cd4b.png)

The space is preserved in the xml structure but for some reason doesn't appear when the document is opened or converted to PDF
```
<w:p w14:paraId="4EA390C4" w14:textId="5D90251E" w:rsidR="00AD46B6" w:rsidRPr="00800E3B" w:rsidRDefault="00800E3B">
  <w:pPr>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
  </w:pPr>
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>Hello Firstname</w:t>
  </w:r>
  <w:proofErr w:type="spellStart" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t></w:t>
  </w:r>
  <w:proofErr w:type="spellEnd" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t> Lastname</w:t>
  </w:r>
  <w:proofErr w:type="spellStart" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t></w:t>
  </w:r>
  <w:proofErr w:type="spellEnd" />
  <w:r>
    <w:rPr>
      <w:lang w:val="en-US" />
    </w:rPr>
    <w:t>!</w:t>
  </w:r>
</w:p>
```

This pull request adds a change which replaces these space occurences with no-break space characters (U+00A0) which fixes this issue.