### PR TITLE
Adjust search for LO binary on Linux to support Arch Linux

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -350,7 +350,7 @@ function generateOnExitCallback (factoryID, isPythonProcess, factoryUniqueName) 
       //   - The event "spawn.close" is received only if stdin, stdout and stderr are closed. So carbone hangs indefinitely :(
       // When killing the oospash parent process, we should close stdin, stdout and stderr and kill the child thread soffice ourself (like "pkill soffice")
       //
-      // Also, we could use SIGTERM. In that case, oosplash (parent) sends the signal to its child... but this signal is not powerful enough to 
+      // Also, we could use SIGTERM. In that case, oosplash (parent) sends the signal to its child... but this signal is not powerful enough to
       // guarantee a shutdown. If LibreOffice hangs, we could wait forever.
       //
       // It is easier to only launch directly soffice.bin directly on Linux (see below)
@@ -611,7 +611,7 @@ function detectLibreOffice (additionalPaths) {
   // overridable file names to look for in the checked paths:
   var _pythonName = 'python';
   var _sofficeName = 'soffice';
-  var _linuxDirnamePattern = /^libreoffice\d+\.\d+$/;
+  var _linuxDirnamePattern = /^libreoffice(\d+\.\d+)?$/;
   var _windowsDirnamePattern = /^LibreOffice( \d+(?:\.\d+)*?)?$/i;
 
   if (process.platform === 'darwin') {
@@ -628,7 +628,9 @@ function detectLibreOffice (additionalPaths) {
     // The Document Foundation packages (.debs, at least) install to /opt,
     // into a directory named after the contained LibreOffice version.
     // Add any existing directories that match this to the list.
-    _pathsToCheck = _pathsToCheck.concat(_listProgramDirectories('/opt', _linuxDirnamePattern));
+    _pathsToCheck = _pathsToCheck
+      .concat(_listProgramDirectories('/opt', _linuxDirnamePattern))
+      .concat(_listProgramDirectories('/usr/lib', _linuxDirnamePattern));;
   }
   else if (process.platform === 'win32') {
     _pathsToCheck = _pathsToCheck


### PR DESCRIPTION
This PR makes two changes to the binary search on linux:

* the version number part of the dirname is made optional
* besides `/opt`, `/usr/lib` is added as a base directory to search for the dirname pattern

These adjustments allow the library to detect the LibreOffice installation on Arch Linux when using the [libreoffice-fresh package](https://archlinux.org/packages/extra/x86_64/libreoffice-fresh/), which installs LibreOffice to `/usr/lib/libreoffice/`