### PR TITLE
Proof of concept to manage whitespace in carbone tags

### DIFF
--- a/lib/extracter.js
+++ b/lib/extracter.js
@@ -116,7 +116,7 @@ var extracter = {
           }
           if (!_res[_uniqueMarkerName]) {
             _res[_uniqueMarkerName]={
-              name     : _word,
+              name     : _word.startsWith("'") && _word.endsWith("'") === true ? _word.slice(1,-1) : _word,
               type     : 'object',
               parent   : _prevMarker,
               parents  : _parents.slice(0),
@@ -218,7 +218,7 @@ var extracter = {
             // create the new array
             if (!_res[_uniqueMarkerName]) {
               _res[_uniqueMarkerName]={
-                name      : _arrayName,
+                name      : _arrayName.startsWith("'") && _arrayName.endsWith("'") === true ? _arrayName.slice(1,-1) : _arrayName,
                 type      : (_isIteratorUsedInCurrentArray === true) ? 'array' : 'objectInArray',
                 parent    : _prevMarker,
                 parents   : _parents.slice(0),
@@ -293,7 +293,7 @@ var extracter = {
           _objParent = _uniqueMarkerName;
         }
         var _xmlPart = {
-          attr       : _word,
+          attr       : _word.startsWith("'") && _word.endsWith("'") === true ? _word.slice(1,-1) : _word,
           formatters : _formaters,
           obj        : _objParent,
           pos        : _markerPos,

--- a/test/test.carbone.js
+++ b/test/test.carbone.js
@@ -310,6 +310,57 @@ describe('Carbone', function () {
     });
   });
 
+  describe('renderXML with whitesapce', function () {
+    it('should accept whitespace in json keys, with single quotes', function (done) {
+      var data = {
+        'new param' : 1
+      };
+      carbone.renderXML('<xml>{d.\'new param\'}</xml>', data, function (err, result) {
+        helper.assert(err+'', 'null');
+        helper.assert(result, '<xml>1</xml>');
+        done();
+      });
+    });
+    it('should accept whitespace in sub-objects', function (done) {
+      var data = {
+        'new param' : {
+          'second level yes' : 2
+        }
+      };
+      carbone.renderXML('<xml>{d.\'new param\'.\'second level yes\'}</xml>', data, function (err, result) {
+        helper.assert(err+'', 'null');
+        helper.assert(result, '<xml>2</xml>');
+        done();
+      });
+    });
+    it('should accept whitespace in array names and children', function (done) {
+      var data = {
+        'new param' : {
+          'second level yes' : [ 
+            { 'sub obj' : 55 },
+            { 'sub obj' : 46 }
+          ]
+        }
+      };
+      carbone.renderXML('<xml>{d.\'new param\'.\'second level yes\'[1].\'sub obj\'}</xml>', data, function (err, result) {
+        helper.assert(err+'', 'null');
+        helper.assert(result, '<xml>46</xml>');
+        done();
+      });
+    });
+    it.skip('should accept whitespace in formatters dynamic paramaters', function (done) {
+      var data = {
+        'new param' : 1,
+        'other param' : 2
+      };
+      carbone.renderXML('<xml>{d.new param:print(.\'other param\')}</xml>', data, function (err, result) {
+        helper.assert(err+'', 'null');
+        helper.assert(result, '<xml>2</xml>');
+        done();
+      });
+    });
+  });
+
   describe('renderXML with dash', function () {
     it('should render an XML string with dash in json keys', function (done) {
       var data = {


### PR DESCRIPTION
It will be the official syntax for upcoming Carbone version:

```
{d.'new param'.'second level yes'}
{d.'new param'.'second level yes'[1].'sub obj'}
```

This pull request was made to share the code with a user who contacted us via our chat.

The upcoming Carbone v5 has a completely new tags parser (faster, with error management, autocompletion, and auto-documentation), and we prefer to focus on that. This code is not finished, but it handles most cases. It would require more time to verify that everything is OK.



